### PR TITLE
Update Pyproject for Initial Release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -612,12 +612,12 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pminit"
-version = "0.6.0"
+version = "0.7.1"
 description = "Post-install hook for PythonMonkey"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "pminit-0.6.0.tar.gz", hash = "sha256:0b6f3fa3fa9fcb2b95c1fff2443f7150220764b8359ae35b0bc0f64ff8620897"},
+    {file = "pminit-0.7.1.tar.gz", hash = "sha256:7e09676055548918456e721de654af801acacc8d6e2f3bf08d7cbe7e2a70ad06"},
 ]
 
 [[package]]
@@ -732,34 +732,35 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pythonmonkey"
-version = "0.6.0"
+version = "0.7.1"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "pythonmonkey-0.6.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:66845e9e4f81c5654495e0ffddf616f7b3f144dfcd152b01be3121258a776eaa"},
-    {file = "pythonmonkey-0.6.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:d8ab351a07f7fd00d515523465d62ed2a41509018cad87a0b748e52066d5fa73"},
-    {file = "pythonmonkey-0.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:14264e69eaf72cb752020cc6a8e1bab2a648808a6f6369e889c6ab144be7ee57"},
-    {file = "pythonmonkey-0.6.0-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:1b88a5b30780b1b1c9a8d48221595ddd8440cb93f0f97e65daab6e0a3e2351aa"},
-    {file = "pythonmonkey-0.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:2cd624877d51fdd02a662c3a547db86df7234aa973ccb6157159b04af9318497"},
-    {file = "pythonmonkey-0.6.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:fc3fabef23673c5158e7702cefe7a6bcaa780efbc8e04304b6252ec02b3413f4"},
-    {file = "pythonmonkey-0.6.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:b930ee55b99994891e58252a812283b385780c08288a4269bd426addb663176d"},
-    {file = "pythonmonkey-0.6.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:9aa3251a1c3bce930db7e95fbea58f6787e8f302fec66f0220c4e8ca39e1b27e"},
-    {file = "pythonmonkey-0.6.0-cp311-cp311-manylinux_2_31_x86_64.whl", hash = "sha256:d5a84c9c80ad121f500b76f2f0556355e3582c8e13f0ae5107333557069c5277"},
-    {file = "pythonmonkey-0.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:137ca8655326e11419763e9900ac53bfc755480c9d5281863f0f895f1bbab817"},
-    {file = "pythonmonkey-0.6.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:1219e4fddd7280684179a1dd2383ff9a63769758053308fb02083ed6b43a2e39"},
-    {file = "pythonmonkey-0.6.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:5661b672f7cdb0cf0162393e722754ab7c1478719bbffc8e917d3396b09d9bb6"},
-    {file = "pythonmonkey-0.6.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0b7ac09648a6f19bc8b6b3e024321fb1f2f4a7f4fe7a1486d9d0d58f6665f5be"},
-    {file = "pythonmonkey-0.6.0-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:8d5d8968982e55aa803440d0837cc425a9c4a852571a7863789f2fcbe86549f3"},
-    {file = "pythonmonkey-0.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b14c8f667acf2b5774df99c0ff410e7893ebcb2032a9784c4f1b0f8d063e564"},
-    {file = "pythonmonkey-0.6.0-cp38-cp38-macosx_13_0_x86_64.whl", hash = "sha256:4e42fe25d986edb249d9c37b3bf289c2a0047ae9b7e12e4e563ed6498d891735"},
-    {file = "pythonmonkey-0.6.0-cp38-cp38-manylinux_2_31_x86_64.whl", hash = "sha256:e11bf3cc5e215dce384ecb3bb346e56c077038a351a294efe2453c2a4aaf2077"},
-    {file = "pythonmonkey-0.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:4a6868dd87319e40b3ec30f051032afa61eb88d5fae13a9805e96f33248705a4"},
-    {file = "pythonmonkey-0.6.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:d6c499be8b00cdae7db4b8600b66783d4b66e95aeca1dc92e27db97928a560a8"},
-    {file = "pythonmonkey-0.6.0-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:9b91ba1e79e3a1c9da525bb940047633b480803a88bb224f4444111f75b1193b"},
-    {file = "pythonmonkey-0.6.0-cp39-cp39-manylinux_2_31_x86_64.whl", hash = "sha256:f03f5148def5d3b43bce5fd1f26c87ba2e9fffa4ec4e4f25669308d0a286ed38"},
-    {file = "pythonmonkey-0.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:30139208a17d9a534966068ff4b5ce5ce6086b429d30e85540211de379c06fb4"},
-    {file = "pythonmonkey-0.6.0.tar.gz", hash = "sha256:f0d6f16cd32a2e42bf24b055b38092c15764f5a6d83c7f09f2c570fc31c31d4d"},
+    {file = "pythonmonkey-0.7.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:f86882a5c1e65a2cc652607c906e5e01af64c701c511e2c94e06b275ec373ac8"},
+    {file = "pythonmonkey-0.7.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:995dc3e030e820f5f4adc34128dcfe4b7832262d3e2e6181e2498cf13380ef46"},
+    {file = "pythonmonkey-0.7.1-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:a93cb3abc82588024696424662df7ffec24527955700897924e3a5feb851acec"},
+    {file = "pythonmonkey-0.7.1-cp310-cp310-manylinux_2_39_x86_64.whl", hash = "sha256:0ab687dc9f0e055f92d518cc446bcecb83240f5b92ede1854e22317b61a7814e"},
+    {file = "pythonmonkey-0.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:5a354445f55e7b5183b2eb8cfca259519272f10f9252cc6fbe7e72d5b54ef2e7"},
+    {file = "pythonmonkey-0.7.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:75820d61f57c28a1a5a9cf7840bd65376541e537c79b50e8076b5550e9b18a9f"},
+    {file = "pythonmonkey-0.7.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:fdb18eb8c6b93c731f1e2547ec7d68a67edb14343062abef9833b6f2d91a17b1"},
+    {file = "pythonmonkey-0.7.1-cp311-cp311-manylinux_2_31_x86_64.whl", hash = "sha256:c3f6b782d8749b6621b2a5a8bf17a3a42709870a7c59f50e6d8af379e5670896"},
+    {file = "pythonmonkey-0.7.1-cp311-cp311-manylinux_2_39_x86_64.whl", hash = "sha256:a1ffc76d7de01d34d12706fd7f909be4c600ed0dbbe6d4d6ab0f3e1734f4854c"},
+    {file = "pythonmonkey-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:09d5bba2100f5c265cd756e2156079f2718f6aa05320067e17bf9870ba3996b5"},
+    {file = "pythonmonkey-0.7.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0f941fff03a4a78fb7e68a260744fd0097409dfe7446c2ca1384c2165dc2eda9"},
+    {file = "pythonmonkey-0.7.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0fc0204667ea9e1e892003e5040fd75d97d62f9a967fefc6143e800b9bca5cce"},
+    {file = "pythonmonkey-0.7.1-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:0ec7cd1c8e3404e320bef579ad5d0f91ddc8eb7bab1f327c6bbc8e8f4639bee9"},
+    {file = "pythonmonkey-0.7.1-cp312-cp312-manylinux_2_39_x86_64.whl", hash = "sha256:cc2157dee61b1aa450e28c7c65e7817c6e4484f2da070218862518cfbdd9e883"},
+    {file = "pythonmonkey-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:1faf91629ffc7ee756b8d0b7df6cf323e07662644e6261e344e5b1d04e4c033f"},
+    {file = "pythonmonkey-0.7.1-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:d0cf934fd14044ac6e8a49a35e7389268343be970a1a85ca5a0cb33378f1fc67"},
+    {file = "pythonmonkey-0.7.1-cp38-cp38-manylinux_2_31_x86_64.whl", hash = "sha256:705db8cfb7d1ac3fa758d7524556d6c71b12f27a4e4a2ef1e49e8c08e4373cb4"},
+    {file = "pythonmonkey-0.7.1-cp38-cp38-manylinux_2_39_x86_64.whl", hash = "sha256:6513c5c2bd44b5e104435814f01d7d6f1a51019cc8155b450de1e8d4cb989ee7"},
+    {file = "pythonmonkey-0.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:4bd02205e1532729805c6b2b4f04f62dd48f4cd0b368d30bfb6a761251df091c"},
+    {file = "pythonmonkey-0.7.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:091d1a30251a0e42c850041032209cfa88674bf21fc832871066f83b7d4d1b5a"},
+    {file = "pythonmonkey-0.7.1-cp39-cp39-manylinux_2_31_x86_64.whl", hash = "sha256:e5d3df0b1cacdf5e761b7f38107fc628477b0b3d93a39dd8b8f34fcfe8c53aed"},
+    {file = "pythonmonkey-0.7.1-cp39-cp39-manylinux_2_39_x86_64.whl", hash = "sha256:d8a21bad9c91ae3acc7cdc5b73ae58ac0ad0681bf076e365d42f844500e8ed19"},
+    {file = "pythonmonkey-0.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:0aa1cb78240c534dfa3d15a37bf00a3414f02497e6956d65b4fc597d0bde991b"},
+    {file = "pythonmonkey-0.7.1.tar.gz", hash = "sha256:9096c0f4412839491630b695a4b8fcaed1cc424a073431056622c5b013610a40"},
 ]
 
 [package.dependencies]
@@ -884,4 +885,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "99eb048b780e3e5572fb97919c50df41113acc7cfa618e3e8809331df9ed9cdd"
+content-hash = "ce0118839c457f22db508e47c488d18c4900f25c4b2a131b995cbd5d556d2e8f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcp"
-version = "0.1.0"
+version = "2.0.0"
 description = "A DCP SDK"
 authors = [
     "Distributive <info@distributive.network>",
@@ -8,14 +8,24 @@ authors = [
 ]
 license = "MIT"
 repository = "https://github.com/Distributive-Network/bifrost2"
-
 packages = [
     { include = "dcp" }
+]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: System :: Distributed Computing"
 ]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pythonmonkey = ">=0.6.0"
+pythonmonkey = ">=0.7.1"
 
 [tool.poetry.build]
 script = "post-install-hook.py"
@@ -27,7 +37,4 @@ pytest = "^7.3.1"
 [build-system]
 requires = ["poetry>=1.1.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.pminit]
-npm_install = true
 


### PR DESCRIPTION
Our first version will be 2.0.0, for rationale why, read https://dstrbtv.slack.com/archives/C015W8DCVH6/p1721787206478649 . Think of it like a 0.0.0 release

I set the development status [in the classifiers](https://pypi.org/classifiers/) to "pre alpha" :     `"Development Status :: 2 - Pre-Alpha",` since currently bifrost2 is not passing the spec since it is heavily in progress.