### PR TITLE
release(pyproject): bump version, add docs for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ Verify your installation is correct by running the test suite:
 Run tests with:
 - `$ poetry run pytest`
 
+## Publishing
+
+We need to upload the tar since we need to run NPM i after installation - this is not possible with the wheel distribution option.
+- `$ poetry build -f sdist`
+- `$ twine upload dist/dcp-<new-version-here>.tar.gz`
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dcp"
-version = "2.0.0"
+version = "2.0.1"
 description = "A DCP SDK"
 authors = [
     "Distributive <info@distributive.network>",


### PR DESCRIPTION
Bumped version and added publishing docs

TODO: this publishing should be done in ci, see https://github.com/orgs/Distributive-Network/projects/5?pane=issue&itemId=70978843