### PR TITLE
feat(work_function)!: apply job args to workfn()

### DIFF
--- a/dcp/api/pyodide_work_function.py
+++ b/dcp/api/pyodide_work_function.py
@@ -68,7 +68,7 @@ def bifrost2_setup():
 
     def slice_handler_deserialization_wrapper(serialized_datum):
         datum = deserialize(serialized_datum, serializers)
-        result = user_work_function(datum)
+        result = user_work_function(datum, *(sys.argv[1:]))
         serialized_result = serialize(result, serializers)
         return serialized_result
 


### PR DESCRIPTION
This is a BREAKING API CHANGE which applies additional job arguments to the user's work function.

So for instance if a user passes job arguments to `compute_for` such as in the following example:

```python

def my_work_fn(datum, a, b, c):
    dcp.progress()
    return datum + a + b + c

job = dcp.compute_for([7], my_work_fn, [10, 100, 1000])

...

print(job.wait()) # will print 1117
```

This is breaking since previoysly job args weren't applied so old user defined workfunctions will raise a typeerror.