### PR TITLE
Deserialize Job Event Params

### DIFF
--- a/dcp/api/job.py
+++ b/dcp/api/job.py
@@ -170,10 +170,9 @@ def job_maker(super_class):
             # deserialize job on event parameters before passing them to user defined callback
             def cb_deserialize_wrapper(callback):
                 def new_cb(*inner_args):
-                    nonlocal callback
                     new_args = []
                     for arg in inner_args:
-                        if isinstance(arg, dict) and bool(arg):
+                        if isinstance(arg, dict):
                             for key in arg:
                                 arg[key] = deserialize(arg[key], self.serializers)
                         new_args.append(deserialize(arg, self.serializers))

--- a/dcp/api/job.py
+++ b/dcp/api/job.py
@@ -167,7 +167,7 @@ def job_maker(super_class):
             return dry.aio.blockify(self._wait)()
 
         def on(self, *args):
-            # deserialize job on event parameters before passing htem to user defined callback
+            # deserialize job on event parameters before passing them to user defined callback
             def cb_deserialize_wrapper(callback):
                 def new_cb(*inner_args):
                     nonlocal callback


### PR DESCRIPTION
Previously, parameters passed to jon event handler callbacks weren't deserialized. See the example below:

example code:
```python
#!/usr/bin/env python3

import dcp
dcp.init()

from dcp import compute_for

def workfn(datum):
    import dcp
    dcp.progress()

    my_dict = {
        'val': datum + datum
    }

    return my_dict

my_j = compute_for([1], workfn)

my_j.on('result', print)

my_j.public.name = 'simple bifrost2 example'
my_j.computeGroups = [{ 'joinKey': 'will', 'joinSecret': 'bozo' }]

my_j.exec()
res = my_j.wait()
```

Before this change, the output would be:
```js
{'job': '0xec837b8Dbfc1eBac8A5C7bc51D7fb2Bd19B6286D', 'sliceNumber': 1.0, 'result': <memory at 0x73bb740e0280>}
```
After this change, the output is now:
```js
{'job': '0x5ECfdb6a856221f070DE657344a5Fe5de8C14e6C', 'sliceNumber': 1.0, 'result': {'val': 2}}
```

the main diff is that now instead of `<memory at 0x73bb740e0280>` it prints `{'val': 2}`